### PR TITLE
feat: upgrade to zod-to-openapi v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "NODE_ENV=test mocha --exit"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^1.2.1"
+    "@asteasolutions/zod-to-openapi": "^2.3.0"
   },
   "peerDependencies": {
     "express": "^5.0.0-beta.1",

--- a/src/openAPI.test.ts
+++ b/src/openAPI.test.ts
@@ -142,9 +142,8 @@ describe("buildOpenAPIDocument", () => {
     const errors = { 401: "Unauthorized", 403: "Forbidden" };
 
     const document = buildOpenAPIDocument({ config, routers, schemaPaths, errors });
-
     const responseSchema = document.paths["/test"].get.responses["200"].content["application/json"].schema;
 
-    expect(responseSchema.allOf.some((a: any) => a.$ref.includes("ResponseSchema"))).to.be.true;
+    expect(responseSchema.$ref.includes("ResponseSchema")).to.be.true;
   });
 });

--- a/src/openAPI.ts
+++ b/src/openAPI.ts
@@ -90,34 +90,46 @@ export function buildOpenAPIDocument(args: {
 
     if (errors[401]) {
       responses[401] = {
-        mediaType: "application/json",
         description: errors[401],
-        schema: ErrorResponse.openapi({ description: "A 401 error" }),
+        content: {
+          "application/json": {
+            schema: ErrorResponse,
+          },
+        },
       };
     }
     if (errors[403]) {
       responses[403] = {
-        mediaType: "application/json",
         description: errors[403],
-        schema: ErrorResponse.openapi({ description: "A 403 error" }),
+        content: {
+          "application/json": {
+            schema: ErrorResponse,
+          },
+        },
       };
     }
 
     // If the request includes path parameters, a 404 error is most likely possible
     if (params) {
       responses[404] = {
-        mediaType: "application/json",
         description: "The item you requested could not be found",
-        schema: ErrorResponse.openapi({ description: "A 404 error" }),
+        content: {
+          "application/json": {
+            schema: ErrorResponse,
+          },
+        },
       };
     }
 
     // If the request includes a query string or request body, Zod 400 errors are possible
     if (query || body) {
       responses[400] = {
-        mediaType: "application/json",
         description: "The request payload or query string parameter you passed was not valid",
-        schema: ErrorResponse.openapi({ description: "A 400 error" }),
+        content: {
+          "application/json": {
+            schema: ErrorResponse,
+          },
+        },
       };
     }
 
@@ -125,16 +137,24 @@ export function buildOpenAPIDocument(args: {
     // we assume the response will be a 204 No Content
     if (responseContentType) {
       responses[200] = {
-        mediaType: responseContentType,
-        schema: z.unknown().openapi({ description: `A ${responseContentType} payload` }),
+        description: `A ${responseContentType} payload`,
+        content: {
+          [responseContentType]: {
+            schema: z.unknown(),
+          },
+        },
       };
     } else if (response) {
       responses[200] = {
-        mediaType: "application/json",
-        schema: referencingNamedSchemas(response)!.openapi({ description: "200" }),
+        description: "200",
+        content: {
+          "application/json": {
+            schema: referencingNamedSchemas(response)!,
+          },
+        },
       };
     } else {
-      responses[204] = z.void().openapi({ description: "No content - successful operation" });
+      responses[204] = { description: "No content - successful operation" };
     }
     let openapiRouteConfig: RouteConfig = {
       tags: [tag || "default"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@asteasolutions/zod-to-openapi@^1.2.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-1.4.1.tgz#3fd2df538f6574d78f0e8a461b6c3be2a2bcd2e5"
-  integrity sha512-gDsZgjY7R/S3Oj+Jw6ICh4ztpVOhBj8vSBeOHqYCNqwiaBWkwVMKUNwwrva3U3RejXlI/KSAaP5lg/EMprd9EQ==
+"@asteasolutions/zod-to-openapi@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-2.3.0.tgz#d911a23870a67b245b2d5ddd13febd7c62661410"
+  integrity sha512-8nVMqcMnfa9BHDSLVUt7AIKubwDLwj8k59OAYV6WbmF7EP3shPmXcXs8bOKjV5tzYLXI+D3HrdgMQMd+dLxpbg==
   dependencies:
     openapi3-ts "^2.0.2"
 


### PR DESCRIPTION
Update the responses to bring them in line with the v2 api. Output changes slightly based on test results needing to be updated.

BREAKING CHANGE: peer dependency update is required