### PR TITLE
feat: upstream v5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "NODE_ENV=test mocha --exit"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^4.8.0"
+    "@asteasolutions/zod-to-openapi": "^5.5.0"
   },
   "peerDependencies": {
     "express": "^5.0.0-beta.1",

--- a/src/openAPI.test.ts
+++ b/src/openAPI.test.ts
@@ -92,7 +92,7 @@ describe("buildOpenAPIDocument", () => {
     const document = buildOpenAPIDocument({ config, routers, schemaPaths, errors, openApiVersion });
 
     expect(document.paths).to.have.property("/test");
-    expect(document.paths["/test"]).to.have.property("get");
+    expect(document.paths!["/test"]).to.have.property("get");
   });
 
   it("should include error responses if defined", () => {
@@ -160,8 +160,8 @@ describe("buildOpenAPIDocument", () => {
     const errors = { 401: "Unauthorized", 403: "Forbidden" };
 
     const document = buildOpenAPIDocument({ config, routers, schemaPaths, errors, openApiVersion });
-    const method = document.paths["/test"].get;
-    const responseSchema = method!.responses["200"].content["application/json"].schema;
+    const method = document.paths!["/test"].get;
+    const responseSchema = method!.responses!["200"].content["application/json"].schema;
 
     expect(responseSchema.$ref.includes("ResponseSchema")).to.be.true;
   });
@@ -186,7 +186,7 @@ describe("buildOpenAPIDocument", () => {
     const errors = { 401: "Unauthorized", 403: "Forbidden" };
 
     const document = buildOpenAPIDocument({ config, routers, schemaPaths, errors, openApiVersion });
-    const method = document.paths["/test"].get;
+    const method = document.paths!["/test"].get;
     // @ts-ignore
     const requestBodySchema = method!.requestBody?.content["application/json"].schema;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@asteasolutions/zod-to-openapi@^4.8.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-4.8.0.tgz#34c29228c5cd0098a534b3536c9f486fafca2cc1"
-  integrity sha512-FQlBeHIhSoEhjddAWD1v2zbeBESfTdaAVQuUr0RY9t0rN8ogoEaGirv2Ne8kQQTAVGydJzUMAOIlPULEOQDoeA==
+"@asteasolutions/zod-to-openapi@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-5.5.0.tgz#f3be8f1e97ece0fcef2e6ff5e9230da8138d20a6"
+  integrity sha512-d5HwrvM6dOKr3XdeF+DmashGvfEc+1oiEfbscugsiwSTrFtuMa7ETpW9sTNnVgn+hJaz+PRxPQUYD7q9/5dUig==
   dependencies:
     openapi3-ts "^4.1.2"
 


### PR DESCRIPTION
Adding support for the v5 of the upstream dependency.

BREAKING CHANGE: types have been changed it appears for openapi version 3.1.0 if passed in as the argument. Paths is now optional on the
  returned object.