### PR TITLE
feat: upgrade upstream to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "NODE_ENV=test mocha --exit"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^6.4.0"
+    "@asteasolutions/zod-to-openapi": "^7.2.0"
   },
   "peerDependencies": {
     "express": "^5.0.0-beta.1",

--- a/src/openAPI.test.ts
+++ b/src/openAPI.test.ts
@@ -67,22 +67,18 @@ describe("buildOpenAPIDocument", () => {
       type: "object",
       properties: {
         address: {
-          items: {
-            anyOf: [
-              {
-                type: "integer",
-              },
-              {
-                type: "string",
-              },
-              {
-                enum: ["street", "avenue", "boulevard"],
-                type: "string",
-              },
-            ],
-          },
-          maxItems: 3,
-          minItems: 3,
+          prefixItems: [
+            {
+              type: "integer",
+            },
+            {
+              type: "string",
+            },
+            {
+              enum: ["street", "avenue", "boulevard"],
+              type: "string",
+            },
+          ],
           type: "array",
         },
         name: { type: "string" },
@@ -95,22 +91,18 @@ describe("buildOpenAPIDocument", () => {
       type: "object",
       properties: {
         address: {
-          items: {
-            anyOf: [
-              {
-                type: "integer",
-              },
-              {
-                type: "string",
-              },
-              {
-                enum: ["street", "avenue", "boulevard"],
-                type: "string",
-              },
-            ],
-          },
-          maxItems: 3,
-          minItems: 3,
+          prefixItems: [
+            {
+              type: "integer",
+            },
+            {
+              type: "string",
+            },
+            {
+              enum: ["street", "avenue", "boulevard"],
+              type: "string",
+            },
+          ],
           type: "array",
         },
         name: { type: "string" },
@@ -268,6 +260,6 @@ describe("buildOpenAPIDocument", () => {
     const responseSchema = document.components!.schemas!.ResponseSchema as SchemaObject;
     const value = responseSchema.properties!.value as SchemaObject;
 
-    expect(value.type).to.equal("integer");
+    expect(value.type).to.equal("string");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@asteasolutions/zod-to-openapi@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-6.4.0.tgz#3081e7f56febdb7c58fcee4dd5cfb3cbcb01742c"
-  integrity sha512-8cxfF7AHHx2PqnN4Cd8/O8CBu/nVYJP9DpnfVLW3BFb66VJDnqI/CczZnkqMc3SNh6J9GiX7JbJ5T4BSP4HZ2Q==
+"@asteasolutions/zod-to-openapi@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.2.0.tgz#19bf1f8bbd380a2ca95d6b1818f7437703da69b1"
+  integrity sha512-Va+Fq1QzKkSgmiYINSp3cASFhMsbdRH/kmCk2feijhC+yNjGoC056CRqihrVFhR8MY8HOZHdlYm2Ns2lmszCiw==
   dependencies:
     openapi3-ts "^4.1.2"
 


### PR DESCRIPTION
Update zod-to-openapi dependency to their version 7. Update tests to reflect the breaking changes upstream.

BREAKING CHANGE: document now treats bigint differently in all openapi versions and tuples differently in 3.1.0

More details here https://github.com/asteasolutions/zod-to-openapi/releases/tag/v7.0.0