### PR TITLE
test: extend schemas with openapi

### DIFF
--- a/mocks/schemas.js
+++ b/mocks/schemas.js
@@ -1,8 +1,16 @@
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 
-const BodySchema = z.object({ name: z.string() });
-const QuerySchema = z.object({ age: z.number().optional() });
+extendZodWithOpenApi(z);
+
+const BaseSchema = z.object({ name: z.string() });
+
+const BodySchema = BaseSchema.openapi("Body", { title: "User", description: "Required user information" });
+const QuerySchema = BaseSchema.extend({ age: z.number().optional() }).openapi({
+  title: "User details",
+  description: "Optional user information",
+});
 const ParamsSchema = z.object({ id: z.string() });
 const ResponseSchema = z.object({ success: z.boolean() });
 
-export { BodySchema, ParamsSchema, QuerySchema, ResponseSchema, UnusedSchema };
+export { BodySchema, ParamsSchema, QuerySchema, ResponseSchema };

--- a/src/openAPI.test.ts
+++ b/src/openAPI.test.ts
@@ -67,6 +67,15 @@ describe("buildOpenAPIDocument", () => {
       type: "object",
       properties: { name: { type: "string" } },
       required: ["name"],
+      title: "User",
+      description: "Required user information",
+    });
+    expect(document.components!.schemas!.QuerySchema).to.deep.equal({
+      type: "object",
+      properties: { name: { type: "string" }, age: { type: "number" } },
+      required: ["name"],
+      title: "User details",
+      description: "Optional user information",
     });
   });
 

--- a/src/openAPIRoute.test.ts
+++ b/src/openAPIRoute.test.ts
@@ -60,7 +60,7 @@ describe("openAPIRoute", () => {
       },
     );
 
-    const req = mockRequest({ name: "John" }, { age: 30 }, { id: "123" });
+    const req = mockRequest({ name: "John" }, { age: 30, name: "John" }, { id: "123" });
     const res = mockResponse();
     const next = mockNext();
 
@@ -75,7 +75,7 @@ describe("openAPIRoute", () => {
       res.json({ success: true });
     });
 
-    const req = mockRequest({ name: 123 }, { age: 30 }, { id: "123" });
+    const req = mockRequest({ name: 123 }, { age: 30, name: "John" }, { id: "123" });
     const res = mockResponse();
     const next = mockNext();
 
@@ -91,7 +91,7 @@ describe("openAPIRoute", () => {
       res.json({ success: true });
     });
 
-    const req = mockRequest({ name: "John" }, { age: "thirty" }, { id: "123" });
+    const req = mockRequest({ name: "John" }, { age: "thirty", name: "John" }, { id: "123" });
     const res = mockResponse();
     const next = mockNext();
 
@@ -107,7 +107,7 @@ describe("openAPIRoute", () => {
       res.json({ success: true });
     });
 
-    const req = mockRequest({ name: "John" }, { age: 30 }, { id: 123 });
+    const req = mockRequest({ name: "John" }, { age: 30, name: "John" }, { id: 123 });
     const res = mockResponse();
     const next = mockNext();
 
@@ -124,7 +124,7 @@ describe("openAPIRoute", () => {
       res.json({ success: "true" });
     });
 
-    const req = mockRequest({ name: "John" }, { age: 30 }, { id: "123" });
+    const req = mockRequest({ name: "John" }, { age: 30, name: "John" }, { id: "123" });
     const res = mockResponse();
     const next = mockNext();
 


### PR DESCRIPTION
Creating a test example for zod schemas that extend one another but already have declared the openapi method