### PR TITLE
feat: support zod 4 and zod-to-openapi v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
+  "packageManager": "yarn@1.22.22",
   "repository": {
     "url": "https://github.com/Foundry376/express-zod-openapi-autogen"
   },
@@ -16,12 +17,12 @@
     "test": "NODE_ENV=test mocha --exit"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^7.2.0"
+    "@asteasolutions/zod-to-openapi": "^8.5.0"
   },
   "peerDependencies": {
     "express": "^5.0.0-beta.1",
     "openapi3-ts": "^4.1.2",
-    "zod": "^3"
+    "zod": "^4"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.0",
@@ -45,6 +46,6 @@
     "semantic-release": "^24.2.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.2.2",
-    "zod": "^3"
+    "zod": "^4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
 export { OpenAPIConfig, OpenAPIDocument, buildOpenAPIDocument, getRoutes } from "./openAPI";
 export { configureOpenAPIRoute, getErrorSummary, openAPIRoute } from "./openAPIRoute";
+export { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+// Re-export from zod-extensions so the `declare module 'zod'` augmentation
+// (which adds `.openapi()` to ZodType) loads when consumers import from
+// this library, even without explicitly importing zod-to-openapi.
+export type { ZodOpenAPIMetadata } from "@asteasolutions/zod-to-openapi/dist/zod-extensions";

--- a/src/openAPI.ts
+++ b/src/openAPI.ts
@@ -1,5 +1,6 @@
 import {
   extendZodWithOpenApi,
+  getRefId,
   OpenApiGeneratorV3,
   OpenApiGeneratorV31,
   OpenAPIRegistry,
@@ -9,7 +10,7 @@ import {
 import { OpenApiVersion } from "@asteasolutions/zod-to-openapi/dist/openapi-generator";
 import { RequestHandler, Router } from "express";
 import type { ComponentsObject } from "openapi3-ts/oas30";
-import { z, ZodArray, ZodEffects, ZodObject } from "zod";
+import { z, ZodArray, ZodObject } from "zod";
 import { getSchemaOfOpenAPIRoute } from "./openAPIRoute";
 import { ErrorResponse } from "./schemas";
 
@@ -45,12 +46,11 @@ export function buildOpenAPIDocument(args: {
     if (!type) {
       return undefined;
     }
-    if (type instanceof ZodEffects) {
-      const nonEffectedObj = schemas.find((s) => s.key === type._def.openapi?._internal?.refId);
-      if (nonEffectedObj) {
-        return nonEffectedObj.registered;
-      } else {
-        return type.innerType();
+    const refId = getRefId(type);
+    if (refId) {
+      const registered = schemas.find((s) => s.key === refId);
+      if (registered) {
+        return registered.registered;
       }
     }
     const named = schemas.find((a) => a.schema === type);
@@ -176,7 +176,7 @@ export function buildOpenAPIDocument(args: {
           ? {
               content: {
                 "application/json": {
-                  schema: referencingNamedSchemas(body),
+                  schema: referencingNamedSchemas(body)!,
                 },
               },
             }

--- a/src/openAPIRoute.test.ts
+++ b/src/openAPIRoute.test.ts
@@ -84,7 +84,7 @@ describe("openAPIRoute", () => {
 
     expect(res.statusCode).to.equal(400);
     expect(res.body).to.have.property("error");
-    expect(res.body.error).to.equal("name: Expected string, received number");
+    expect(res.body.error).to.equal("name: Invalid input: expected string, received number");
   });
 
   it("should return 400 if query validation fails", async () => {
@@ -100,7 +100,7 @@ describe("openAPIRoute", () => {
 
     expect(res.statusCode).to.equal(400);
     expect(res.body).to.have.property("error");
-    expect(res.body.error).to.equal("age: Expected number, received string");
+    expect(res.body.error).to.equal("age: Invalid input: expected number, received string");
   });
 
   it("should return 400 if params validation fails", async () => {
@@ -116,7 +116,7 @@ describe("openAPIRoute", () => {
 
     expect(res.statusCode).to.equal(400);
     expect(res.body).to.have.property("error");
-    expect(res.body.error).to.equal("id: Expected string, received number");
+    expect(res.body.error).to.equal("id: Invalid input: expected string, received number");
   });
 
   it("should validate response and log warning if it doesn't match schema", () => {
@@ -154,7 +154,7 @@ describe("openAPIRoute", () => {
 
       expect(handlerCalled).to.equal(true);
       expect(res.statusCode).to.equal(200);
-      expect(consoleWarnStub).to.have.been.called.with("openAPIRoute: body validation failed: name: Expected string, received number");
+      expect(consoleWarnStub).to.have.been.called.with("openAPIRoute: body validation failed: name: Invalid input: expected string, received number");
     });
 
     it("should log warning and call handler when query validation fails with per-route warnOnly", () => {
@@ -174,7 +174,7 @@ describe("openAPIRoute", () => {
 
       expect(handlerCalled).to.equal(true);
       expect(res.statusCode).to.equal(200);
-      expect(consoleWarnStub).to.have.been.called.with("openAPIRoute: query validation failed: age: Expected number, received string");
+      expect(consoleWarnStub).to.have.been.called.with("openAPIRoute: query validation failed: age: Invalid input: expected number, received string");
     });
 
     it("should log warning and call handler when global warnOnly is set", () => {
@@ -196,7 +196,7 @@ describe("openAPIRoute", () => {
 
       expect(handlerCalled).to.equal(true);
       expect(res.statusCode).to.equal(200);
-      expect(consoleWarnStub).to.have.been.called.with("openAPIRoute: body validation failed: name: Expected string, received number");
+      expect(consoleWarnStub).to.have.been.called.with("openAPIRoute: body validation failed: name: Invalid input: expected string, received number");
     });
 
     it("should return 400 when per-route warnOnly: false overrides global warnOnly: true", () => {
@@ -214,7 +214,7 @@ describe("openAPIRoute", () => {
 
       expect(res.statusCode).to.equal(400);
       expect(res.body).to.have.property("error");
-      expect(res.body.error).to.equal("name: Expected string, received number");
+      expect(res.body.error).to.equal("name: Invalid input: expected string, received number");
     });
   });
 });

--- a/src/openAPIRoute.ts
+++ b/src/openAPIRoute.ts
@@ -73,7 +73,7 @@ type SchemaDefinition<
   warnOnly?: boolean;
 };
 
-const check = <TType>(obj?: any, schema?: ZodSchema<TType>): z.SafeParseReturnType<TType, TType> => {
+const check = <TType>(obj?: any, schema?: ZodSchema<TType>): z.ZodSafeParseResult<TType> => {
   if (!schema) {
     return { success: true, data: obj };
   }
@@ -169,7 +169,11 @@ export const openAPIRoute = <
     }
 
     try {
-      return await middleware(req as unknown as Request<TParams, any, TBody, TQuery>, res, next);
+      return await middleware(
+        req as unknown as Request<z.output<TParams>, any, z.output<TBody>, z.output<TQuery>>,
+        res,
+        next,
+      );
     } catch (err) {
       return next(err);
     }

--- a/src/openAPIRoute.ts
+++ b/src/openAPIRoute.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { RouteConfig } from "@asteasolutions/zod-to-openapi";
 import { NextFunction, Request, RequestHandler, Response } from "express";
-import { ZodError, ZodSchema, ZodTypeAny, z } from "zod";
+import { ZodError, z } from "zod";
 import { ErrorResponse } from "./schemas";
 
 const globalConfig: { warnOnly: boolean } = { warnOnly: false };
@@ -22,12 +22,12 @@ type ValidatedMiddleware<ZBody, ZQuery, ZParams, ZResponse> = (
   next: NextFunction,
 ) => any;
 
-type SchemaDefinition<
-  TBody extends ZodTypeAny,
-  TQuery extends ZodTypeAny,
-  TParams extends ZodTypeAny,
-  TResponse extends ZodTypeAny,
-> = {
+// When a schema is declared, infer its output. When no schema is declared
+// (the property is undefined), default to `any` to preserve the behavior of
+// the legacy zod 3 typings, which used `ZodTypeAny = ZodType<any, any, any>`.
+type InferOutput<T> = T extends { _zod: { output: infer O } } ? O : any;
+
+type SchemaDefinition<TBody, TQuery, TParams, TResponse> = {
   /**The category this route should be displayed in within the OpenAPI documentation. */
   tag: string;
   /**A short one-line description of the route */
@@ -73,12 +73,11 @@ type SchemaDefinition<
   warnOnly?: boolean;
 };
 
-const check = <TType>(obj?: any, schema?: ZodSchema<TType>): z.ZodSafeParseResult<TType> => {
+const check = (obj: any, schema?: z.ZodType<any, any, any>): z.ZodSafeParseResult<any> => {
   if (!schema) {
     return { success: true, data: obj };
   }
-  const r = schema.safeParse(obj);
-  return r;
+  return schema.safeParse(obj);
 };
 
 type ValidatedRequestHandler = RequestHandler & {
@@ -97,19 +96,19 @@ export const getErrorSummary = (error: ZodError<unknown>) => {
  * Note: This function wraps the route handler rather than just being a chained piece
  * of middleware so that we can validate the response shape as well as the request shape.
  */
-export const openAPIRoute = <
-  TBody extends ZodTypeAny,
-  TQuery extends ZodTypeAny,
-  TParams extends ZodTypeAny,
-  TResponse extends ZodTypeAny,
->(
+export const openAPIRoute = <TBody, TQuery, TParams, TResponse>(
   schema: SchemaDefinition<TBody, TQuery, TParams, TResponse>,
-  middleware: ValidatedMiddleware<z.infer<TBody>, z.infer<TQuery>, z.infer<TParams>, z.infer<TResponse>>,
+  middleware: ValidatedMiddleware<
+    InferOutput<TBody>,
+    InferOutput<TQuery>,
+    InferOutput<TParams>,
+    InferOutput<TResponse>
+  >,
 ): RequestHandler => {
   const fn: ValidatedRequestHandler = async (req, res, next) => {
-    const bodyResult = check(req.body, schema.body);
-    const queryResult = check(req.query, schema.query);
-    const paramResult = check(req.params, schema.params);
+    const bodyResult = check(req.body, schema.body as z.ZodType<any, any, any> | undefined);
+    const queryResult = check(req.query, schema.query as z.ZodType<any, any, any> | undefined);
+    const paramResult = check(req.params, schema.params as z.ZodType<any, any, any> | undefined);
 
     const warnOnly = schema.warnOnly ?? globalConfig.warnOnly;
 
@@ -147,7 +146,7 @@ export const openAPIRoute = <
       // In dev + test, validate that the JSON response from the endpoint matches
       // the Zod schemas. In production, we skip this because it's just time consuming
       if (process.env.NODE_ENV !== "production") {
-        const acceptable = z.union([schema.response as ZodTypeAny, ErrorResponse]);
+        const acceptable = z.union([schema.response as z.ZodType<any, any, any>, ErrorResponse]);
         const result = schema.response ? acceptable.safeParse(body) : { success: true };
 
         if (result.success === false && "error" in result) {
@@ -170,7 +169,7 @@ export const openAPIRoute = <
 
     try {
       return await middleware(
-        req as unknown as Request<z.output<TParams>, any, z.output<TBody>, z.output<TQuery>>,
+        req as unknown as Request<InferOutput<TParams>, any, InferOutput<TBody>, InferOutput<TQuery>>,
         res,
         next,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@asteasolutions/zod-to-openapi@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.2.0.tgz#19bf1f8bbd380a2ca95d6b1818f7437703da69b1"
-  integrity sha512-Va+Fq1QzKkSgmiYINSp3cASFhMsbdRH/kmCk2feijhC+yNjGoC056CRqihrVFhR8MY8HOZHdlYm2Ns2lmszCiw==
+"@asteasolutions/zod-to-openapi@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz#f073822daad87c4ab2ae991ee86b1a5070ac9942"
+  integrity sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==
   dependencies:
     openapi3-ts "^4.1.2"
 
@@ -4875,7 +4875,7 @@ yoctocolors@^2.0.0:
   resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.1.tgz#e0167474e9fbb9e8b3ecca738deaa61dd12e56fc"
   integrity sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==
 
-zod@^3:
-  version "3.23.8"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
-  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
+zod@^4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary
- Upgrades peer `zod` to `^4` (breaking) and `@asteasolutions/zod-to-openapi` to `^8.5.0`
- Migrates the small surface that depended on removed/renamed zod 4 APIs (`ZodEffects`, `SafeParseReturnType`)
- Fixes validated-middleware type inference so `req.params/body/query` infer correctly under zod 4's stricter input/output split — without this, every downstream `openAPIRoute(...)` handler loses its inferred request types
- Replaces the old `_def.openapi._internal.refId` introspection with the public `getRefId()` helper from zod-to-openapi v8
- Pins `packageManager` to `yarn@1.22.22` to match the existing v1 lockfile (corepack now auto-selects the right yarn)